### PR TITLE
Fix mypy configuration and add type hints

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,5 @@
-[tool.mypy]
-plugins = sqlmodel.mypy
-strict = true
+[mypy]
+strict = True
+
+[mypy-celery.*]
+ignore_missing_imports = True

--- a/src/chemfetch/api/main.py
+++ b/src/chemfetch/api/main.py
@@ -5,5 +5,5 @@ app = FastAPI(title="ChemFetch API")
 
 
 @app.get("/health", tags=["utils"])
-async def health():
+async def health() -> dict[str, str]:
     return {"status": "ok"}

--- a/src/chemfetch/tasks/app.py
+++ b/src/chemfetch/tasks/app.py
@@ -1,7 +1,7 @@
 # filepath: src/chemfetch/tasks/app.py
 from celery import Celery
 
-celery_app = Celery(
+celery_app: Celery = Celery(
     "chemfetch",
     broker="redis://localhost:6379/0",
     backend="redis://localhost:6379/1",

--- a/src/chemfetch/tasks/demo.py
+++ b/src/chemfetch/tasks/demo.py
@@ -2,6 +2,6 @@
 from .app import celery_app
 
 
-@celery_app.task
-def add(x, y):
+@celery_app.task  # type: ignore[misc]
+def add(x: int, y: int) -> int:
     return x + y


### PR DESCRIPTION
## Summary
- fix mypy.ini section name and ignore missing celery stubs
- add return type on health endpoint
- type annotate Celery app and demo task

## Testing
- `mypy --install-types --non-interactive src/chemfetch`
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c7b2a5708832fbfa5387bbbcd3a93