### PR TITLE
Fix expo TypeScript build issues

### DIFF
--- a/app/register/[id].tsx
+++ b/app/register/[id].tsx
@@ -1,6 +1,13 @@
 // filepath: app/(main)/register/[id].tsx
 import { useLocalSearchParams } from "expo-router";
-import { View, Text, ActivityIndicator, Pressable, Linking } from "react-native";
+import {
+  View,
+  Text,
+  ActivityIndicator,
+  Pressable,
+  Linking,
+  StyleSheet,
+} from "react-native";
 import { useQuery } from "@tanstack/react-query";
 import { fetchProduct } from "../../src/lib/api";
 
@@ -45,7 +52,7 @@ export default function RegisterScreen() {
       {data.sdsUrl && (
         <Pressable
           style={styles.button}
-          onPress={() => Linking.openURL(data.sdsUrl)}
+          onPress={() => Linking.openURL(data.sdsUrl!)}
         >
           <Text style={styles.buttonText}>Open SDS PDF</Text>
         </Pressable>
@@ -54,7 +61,7 @@ export default function RegisterScreen() {
   );
 }
 
-const styles = {
+const styles = StyleSheet.create({
   center: {
     flex: 1,
     alignItems: "center",
@@ -70,4 +77,4 @@ const styles = {
     alignItems: "center",
   },
   buttonText: { color: "#fff", fontSize: 16 },
-};
+});

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,0 @@
-import { registerRootComponent } from 'expo';
-
-import App from './App';
-
-// registerRootComponent calls AppRegistry.registerComponent('main', () => App);
-// It also ensures that whether you load the app in Expo Go or in a native build,
-// the environment is set up appropriately
-registerRootComponent(App);


### PR DESCRIPTION
## Summary
- resolve Expo component style typing errors by using `StyleSheet.create`
- remove unused `index.ts`

## Testing
- `ruff check src --fix`
- `mypy src`
- `pytest -q`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_687cc5a6d840832f87050ad73ea7fe76