### PR TITLE
Implement product lookup endpoint

### DIFF
--- a/src/chemfetch/api/main.py
+++ b/src/chemfetch/api/main.py
@@ -1,7 +1,11 @@
 # filepath: src/chemfetch/api/main.py
 from fastapi import FastAPI
 
+from .routes import products
+
 app = FastAPI(title="ChemFetch API")
+
+app.include_router(products.router)
 
 
 @app.get("/health", tags=["utils"])

--- a/src/chemfetch/api/routes/products.py
+++ b/src/chemfetch/api/routes/products.py
@@ -1,0 +1,44 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import Optional
+
+router = APIRouter(prefix="/products", tags=["products"])
+
+
+class Product(BaseModel):
+    id: int
+    gtin: str
+    name: str
+    vendor: Optional[str] = None
+    sds_url: Optional[str] = None
+    last_revision: Optional[str] = None
+
+
+# Temporary in-memory database
+_FAKE_PRODUCTS: dict[str, Product] = {
+    "9311111111111": Product(
+        id=1,
+        gtin="9311111111111",
+        name="Sample Solvent",
+        vendor="ChemCorp",
+        sds_url="https://example.com/sds/sample.pdf",
+        last_revision="2024-01-01",
+    )
+}
+
+
+def _trigger_sds_retrieval(gtin: str) -> None:
+    """Placeholder for asynchronous SDS retrieval."""
+    # TODO: integrate Celery task
+    print(f"[stub] fetching SDS for {gtin}")
+
+
+@router.get("/{gtin}", response_model=Product)
+async def lookup_product(gtin: str) -> Product:
+    """Return product details or trigger SDS retrieval if unknown."""
+    product = _FAKE_PRODUCTS.get(gtin)
+    if product:
+        return product
+
+    _trigger_sds_retrieval(gtin)
+    raise HTTPException(status_code=404, detail="Product not found")


### PR DESCRIPTION
## Summary
- create `src/chemfetch/api/routes/products.py` for `/products/{gtin}` lookup
- wire router into FastAPI app

## Testing
- `ruff check src/chemfetch/api/main.py src/chemfetch/api/routes/products.py`
- `mypy src/chemfetch/api/main.py src/chemfetch/api/routes/products.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cd1c4d79c832f8fd4592601af6314